### PR TITLE
Add pmtiles source support (uses new experimental maplibre-native with pmtiles support)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "maplibre-native"]
 	path = maplibre-native
-	url = https://github.com/maplibre/maplibre-native.git
+	url = https://github.com/tdcosta100/maplibre-native.git

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you prefer to run tilerender without Docker, follow these steps:
 1. **Clone the Repository:**
 
    ```bash
-   git clone https://github.com/hstin-de/tilerender.git
+   git clone --recurse-submodules https://github.com/acalcutt/tilerender.git
    cd tilerender
    ```
 
@@ -87,6 +87,7 @@ If you prefer to run tilerender without Docker, follow these steps:
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DMLN_WITH_CLANG_TIDY=OFF \
     -DMLN_WITH_COVERAGE=OFF \
+    -DMLN_WITH_PMTILES=ON \
     -DMLN_DRAWABLE_RENDERER=ON \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
     

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you prefer to run tilerender without Docker, follow these steps:
 1. **Clone the Repository:**
 
    ```bash
-   git clone --recurse-submodules https://github.com/acalcutt/tilerender.git
+   git clone --recurse-submodules https://github.com/hstin-de/tilerender.git
    cd tilerender
    ```
 


### PR DESCRIPTION
This PR adds experimental pmtiles source support. It uses the maplibre-native changes from https://github.com/maplibre/maplibre-native/pull/2882 , which adds the support.

This is pins maplibre-native to 
https://github.com/tdcosta100/maplibre-native/tree/5e9e6cc71f53a6f61a628af3e4f0485e15799405

The build adds this flag so maplibre-native will get built with pmtiles support
`-DMLN_WITH_PMTILES=ON`


To use pmtiles as a source, you would use this syntax
**http/https**
```
    "openmaptiles": {
      "type": "vector",
      "url": "pmtiles://https://wifidb.net/demo/pmtiles/sources/planetiler-openmaptiles-latest.pmtiles"
    },
```
**local file**
```
    "openmaptiles": {
      "type": "raster",
      "url": "pmtiles://file:///opt/basemaps/planetiler-openmaptiles-latest.pmtiles"
    },
```


**Known issues.**
Some of my older pmtiles were converted from mbtiles that did not have a min/max zoom. the older version of the pmtiles converter did not handle this well, but newer versions do. these older files seem to not work with the current experimental code. I assume changes will need to be made in the PR or my files need to be reconverted. that error looks like this
![image](https://github.com/user-attachments/assets/523dc79e-985d-4e47-9868-fdf91993d9c7)

